### PR TITLE
Expose `ConsentMessage.parse` to allow unit test

### DIFF
--- a/Sources/Pam/consent/ConsentMessage.swift
+++ b/Sources/Pam/consent/ConsentMessage.swift
@@ -194,7 +194,7 @@ public struct ConsentMessage: BaseConsentMessage{
         )
     }
     
-    static func parse(json:Json) -> ConsentMessage{
+    public static func parse(json:Json) -> ConsentMessage{
         let id = json[\.consent_message_id].string ?? ""
         let name = json[\.name].string ?? ""
         let description = json[\.description].string ?? ""


### PR DESCRIPTION
## What Happened

public the method `static func parse(json:Json) -> ConsentMessage` in ConsentMessage.swift to allow unit test from external usage.

## Insight

Stubbing `loadConsentDetails` or `submitConsent` is currently impossible without exposing `init`

## Proof of Work

Example usage and passing tests
<img width="710" alt="Screen Shot 2022-08-26 at 14 44 52" src="https://user-images.githubusercontent.com/6356137/186850589-4075f2da-59ff-4db0-b6a1-09c40579698f.png">
